### PR TITLE
Carve

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,7 @@ use posix::MmapInner;
 use std::{fs, io, slice};
 use std::path::Path;
 
-mod mmap_sliver;
-use mmap_sliver::{ MmapSliver, carve };
+pub mod mmap_sliver;
 
 /// Memory map protection.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@ use posix::MmapInner;
 use std::{fs, io, slice};
 use std::path::Path;
 
+mod mmap_sliver;
+use mmap_sliver::{ MmapSliver, carve };
+
 /// Memory map protection.
 ///
 /// Determines how a memory map may be used. If the memory map is backed by a file, then the file

--- a/src/mmap_sliver.rs
+++ b/src/mmap_sliver.rs
@@ -20,20 +20,20 @@ pub struct MmapSliver {
 	inner: MmapInner
 }
 
-pub unsafe fn carve(mmap: Mmap, _: Vec<(usize,usize)> ) -> Vec<MmapSliver> {
+pub unsafe fn carve(mmap: Mmap, ranges: Vec<(usize,usize)> ) -> Vec<MmapSliver> {
 	let parent = Rc::new( RefCell::new(mmap) );
 
 	let ptr = parent.borrow().ptr() as *mut libc::c_void;
-	let len = parent.borrow().len();
 
-
-	vec![ MmapSliver{
-		parent: parent,
-		inner: MmapInner {
-			ptr: ptr,
-			len: len
-		}
-	}]
+    ranges.into_iter().map(|(start_offset,end_offset)| {
+        MmapSliver {
+            parent: parent.clone(),
+            inner: MmapInner {
+                ptr: ptr.offset(start_offset as isize),
+                len: (end_offset-start_offset)
+            }
+        }
+    }).collect()
 }
 
 impl MmapSliver {

--- a/src/mmap_sliver.rs
+++ b/src/mmap_sliver.rs
@@ -1,0 +1,83 @@
+use std::{io, slice};
+use std::rc::Rc;
+use std::cell::RefCell;
+
+use ::Mmap;
+
+#[cfg(target_os = "windows")]
+use super::windows::MmapInner;
+
+#[cfg(not(target_os = "windows"))]
+use super::posix::MmapInner;
+
+pub struct MmapSliver {
+	// The Rc tracks when to drop
+	// The RefCell allows mutable borrows of parent
+	// for flushing
+	parent: Rc< RefCell<Mmap> >,
+	inner: MmapInner
+}
+
+pub unsafe fn carve(mmap: Mmap, carvings: Vec<(usize,usize)> ) -> Vec<MmapSliver> {
+	let parent = Rc::new( RefCell::new(mmap) );
+
+	let ptr = parent.borrow().ptr();
+	let len = parent.borrow().len();
+
+
+
+	vec![ MmapSliver{
+		parent: parent,
+		inner: MmapInner {
+			ptr: ptr,
+			len: len
+		}
+	}]
+}
+
+impl MmapSliver {
+    pub fn flush(&mut self) -> io::Result<()> {
+        self.parent.borrow_mut().flush()
+    }
+
+    pub fn flush_async(&mut self) -> io::Result<()> {
+        self.parent.borrow_mut().flush_async()
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn ptr(&self) -> *const u8 {
+        self.inner.ptr()
+    }
+
+    pub fn mut_ptr(&mut self) -> *mut u8 {
+        self.inner.mut_ptr()
+    }
+
+    pub unsafe fn as_slice(&self) -> &[u8] {
+        slice::from_raw_parts(self.ptr(), self.len())
+    }
+
+    pub unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
+        slice::from_raw_parts_mut(self.mut_ptr(), self.len())
+    }
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use super::super::*;
+
+	#[test]
+	fn carve_mmap(){
+        let expected_len = 128;
+        let mut mmap = Mmap::anonymous(expected_len, Protection::ReadWrite).unwrap();
+
+
+        carve(mmap, vec![(10,10)]);
+
+        assert_eq!(mmap.len(), 123);
+	}
+}

--- a/src/posix.rs
+++ b/src/posix.rs
@@ -26,8 +26,8 @@ impl Protection {
 }
 
 pub struct MmapInner {
-    ptr: *mut libc::c_void,
-    len: usize,
+    pub ptr: *mut libc::c_void,
+    pub len: usize,
 }
 
 impl MmapInner {


### PR DESCRIPTION
I'm hacking away on the idea of "carving" a mmap in to many slivers. I'm thinking in the same vein as `split_at_mut`. The code consumes a Mmap and uses `Rc` to keep the `Mmap` alive long enough so slivers are always valid.

 - [ ] Doesn't work. Segfault up at the end of the `cargo test` run
 - [ ] Come up with good names for what's going on. The names `carve`/`sliver` aren't great
 - [ ] Revert changes to make `Mmap` properties `pub` (create a constructor function `with_raw_parts`?)
 - [ ] Does this need a multithreaded version as well?

Does this look at all sane? If I can get it to work it will really scratch my itch for safely carving up a Mmap and moving those slivers in to structs.