### PR TITLE
View

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ use std::cell::UnsafeCell;
 use std::fs::{self, File};
 use std::path::Path;
 use std::rc::Rc;
+use std::sync::Arc;
 
 /// Memory map protection.
 ///
@@ -180,11 +181,20 @@ impl Mmap {
         slice::from_raw_parts_mut(self.mut_ptr(), self.len())
     }
 
+    /// Creates a splittable mmap view from the mmap.
     pub fn into_view(self) -> MmapView {
         let len = self.len();
         MmapView { inner: Rc::new(UnsafeCell::new(self)),
                    offset: 0,
                    len: len }
+    }
+
+    /// Creates a thread-safe splittable mmap view from the mmap.
+    pub fn into_view_sync(self) -> MmapViewSync {
+        let len = self.len();
+        MmapViewSync { inner: Arc::new(UnsafeCell::new(self)),
+                       offset: 0,
+                       len: len }
     }
 }
 
@@ -292,8 +302,116 @@ impl MmapView {
     pub unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
         &mut self.inner_mut().as_mut_slice()[self.offset..self.offset + self.len]
     }
-
 }
+
+/// A thread-safe view of a memory map.
+///
+/// The view may be split into disjoint ranges, each of which will share the
+/// underlying memory map.
+///
+/// A mmap view is not cloneable.
+pub struct MmapViewSync {
+    inner: Arc<UnsafeCell<Mmap>>,
+    offset: usize,
+    len: usize,
+}
+
+impl MmapViewSync {
+
+    /// Split the view into disjoint pieces.
+    ///
+    /// The provided offset must be less than the view's length.
+    pub fn split_at(self, offset: usize) -> (MmapViewSync, MmapViewSync) {
+        assert!(offset < self.len, "MmapView split offset must be less than the view length");
+        let MmapViewSync { inner, offset: self_offset, len: self_len } = self;
+        (MmapViewSync { inner: inner.clone(),
+                    offset: self_offset,
+                    len: offset },
+         MmapViewSync { inner: inner,
+                    offset: self_offset + offset,
+                    len: self_len - offset })
+    }
+
+    /// Get a reference to the inner mmap.
+    ///
+    /// The caller must ensure that memory outside the `offset`/`len` range is
+    /// not accessed.
+    fn inner(&self) -> &Mmap {
+        unsafe {
+            &*self.inner.get()
+        }
+    }
+
+    /// Get a mutable reference to the inner mmap.
+    ///
+    /// The caller must ensure that memory outside the `offset`/`len` range is
+    /// not accessed.
+    fn inner_mut(&self) -> &mut Mmap {
+        unsafe {
+            &mut *self.inner.get()
+        }
+    }
+
+    /// Flushes outstanding view modifications to disk.
+    ///
+    /// When this returns with a non-error result, all outstanding changes to a file-backed memory
+    /// map view are guaranteed to be durably stored. The file's metadata (including last
+    /// modification timestamp) may not be updated.
+    pub fn flush(&mut self) -> io::Result<()> {
+        // TODO: this should be restricted to flushing the view.
+        self.inner_mut().flush()
+    }
+
+    /// Asynchronously flushes outstanding memory map view modifications to disk.
+    ///
+    /// This method initiates flushing modified pages to durable storage, but it will not wait
+    /// for the operation to complete before returning. The file's metadata (including last
+    /// modification timestamp) may not be updated.
+    pub fn flush_async(&mut self) -> io::Result<()> {
+        // TODO: this should be restricted to flushing the view.
+        self.inner_mut().flush_async()
+    }
+
+    /// Returns the length of the memory map view.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns a pointer to the mapped mapped.
+    ///
+    /// See `Mmap::as_slice` for invariants that must hold when dereferencing the pointer.
+    pub fn ptr(&self) -> *const u8 {
+        unsafe { self.inner().ptr().offset(self.offset as isize) }
+    }
+
+    /// Returns a pointer to the mapped memory.
+    ///
+    /// See `Mmap::as_mut_slice` for invariants that must hold when dereferencing the pointer.
+    pub fn mut_ptr(&mut self) -> *mut u8 {
+        unsafe { self.inner_mut().mut_ptr().offset(self.offset as isize) }
+    }
+
+    /// Returns the memory mapped file as an immutable slice.
+    ///
+    /// ## Unsafety
+    ///
+    /// The caller must ensure that the file is not concurrently modified.
+    pub unsafe fn as_slice(&self) -> &[u8] {
+        &self.inner().as_slice()[self.offset..self.offset + self.len]
+    }
+
+    /// Returns the memory mapped file as a mutable slice.
+    ///
+    /// ## Unsafety
+    ///
+    /// The caller must ensure that the file is not concurrently accessed.
+    pub unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.inner_mut().as_mut_slice()[self.offset..self.offset + self.len]
+    }
+}
+
+unsafe impl Sync for MmapViewSync {}
+unsafe impl Send for MmapViewSync {}
 
 #[cfg(test)]
 mod test {
@@ -480,7 +598,7 @@ mod test {
     }
 
     #[test]
-    fn test_view() {
+    fn view() {
         let len = 128;
         let split = 32;
         let mut view = Mmap::anonymous(len, Protection::ReadWrite).unwrap().into_view();
@@ -494,5 +612,32 @@ mod test {
 
         assert_eq!(&incr[0..split], unsafe { view1.as_slice() });
         assert_eq!(&incr[split..], unsafe { view2.as_slice() });
+    }
+
+    #[test]
+    fn view_sync() {
+        let len = 128;
+        let split = 32;
+        let mut view = Mmap::anonymous(len, Protection::ReadWrite).unwrap().into_view_sync();
+        let incr = (0..len).map(|n| n as u8).collect::<Vec<_>>();
+        // write values into the view
+        unsafe { view.as_mut_slice() }.write_all(&incr[..]).unwrap();
+
+        let (view1, view2) = view.split_at(32);
+        assert_eq!(view1.len(), split);
+        assert_eq!(view2.len(), len - split);
+
+        assert_eq!(&incr[0..split], unsafe { view1.as_slice() });
+        assert_eq!(&incr[split..], unsafe { view2.as_slice() });
+    }
+
+    #[test]
+    fn view_sync_send() {
+        let view = Arc::new(Mmap::anonymous(128, Protection::ReadWrite).unwrap().into_view_sync());
+        thread::spawn(move || {
+            unsafe {
+                view.as_slice();
+            }
+        });
     }
 }

--- a/src/posix.rs
+++ b/src/posix.rs
@@ -77,8 +77,10 @@ impl MmapInner {
         }
     }
 
-    pub fn flush(&mut self) -> io::Result<()> {
-        let result = unsafe { libc::msync(self.ptr, self.len as libc::size_t, libc::MS_SYNC) };
+    pub fn flush(&mut self, offset: usize, len: usize) -> io::Result<()> {
+        let result = unsafe { libc::msync(self.ptr.offset(offset as isize),
+                                          len as libc::size_t,
+                                          libc::MS_SYNC) };
         if result == 0 {
             Ok(())
         } else {
@@ -86,8 +88,10 @@ impl MmapInner {
         }
     }
 
-    pub fn flush_async(&mut self) -> io::Result<()> {
-        let result = unsafe { libc::msync(self.ptr, self.len as libc::size_t, libc::MS_ASYNC) };
+    pub fn flush_async(&mut self, offset: usize, len: usize) -> io::Result<()> {
+        let result = unsafe { libc::msync(self.ptr.offset(offset as isize),
+                                          len as libc::size_t,
+                                          libc::MS_ASYNC) };
         if result == 0 {
             Ok(())
         } else {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -98,13 +98,14 @@ impl MmapInner {
         }
     }
 
-    pub fn flush(&mut self) -> io::Result<()> {
-        try!(self.flush_async());
+    pub fn flush(&mut self, offset: usize, len: usize) -> io::Result<()> {
+        try!(self.flush_async(offset, len));
         if let Some(ref mut file) = self.file { file.sync_data() } else { Ok(()) }
     }
 
-    pub fn flush_async(&mut self) -> io::Result<()> {
-        let result = unsafe { kernel32::FlushViewOfFile(self.ptr, 0) };
+    pub fn flush_async(&mut self, offset: usize, len: usize) -> io::Result<()> {
+        let result = unsafe { kernel32::FlushViewOfFile(self.ptr.offset(offset as isize),
+                                                        len as u64) };
         if result != 0 {
             Ok(())
         } else {


### PR DESCRIPTION
Implementation of `MmapView`, and a thread safe variant, `MmapViewSync`.  The mmap view allows splitting a mmap into distinct views which are restricted to operating on a disjoint subset of the mmap.

CC #10 #7 #3 